### PR TITLE
fix: remove private positioning & research links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,5 +149,3 @@ We welcome new team templates. See [`docs/contributing.md`](docs/contributing.md
 ---
 
 Built by [COCO](https://github.com/coco-xyz) — making human × agent collaboration real.
-
-> **Positioning & research:** [hxa-teams-positioning.md](https://jessie.coco.site/hxa-teams-positioning.md) | [hxa-teams-landscape-research.md](https://jessie.coco.site/hxa-teams-landscape-research.md)


### PR DESCRIPTION
## Summary
- Remove internal positioning & research links from public README
- These links (`hxa-teams-positioning.md`, `hxa-teams-landscape-research.md`) point to private documents on jessie.coco.site that should not be publicly visible

## Test plan
- [x] Verify README renders correctly without the links
- [x] No other content affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)